### PR TITLE
Add PersonaEvolve / PEBA (EMNLP 2025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ Oct 2024
 ICLR 2024 submission. [[Paper](https://openreview.net/forum?id=eojWsJQ2fe)] \
 Oct 2024 
 
+**Implicit Behavioral Alignment of Language Agents in High-Stakes Crowd Simulations (PersonaEvolve)** \
+*Yunzhe Wang, Gale M. Lucas, Burcin Becerik-Gerber, Volkan Ustun* \
+EMNLP 2025. [[Paper](https://arxiv.org/abs/2509.16457)] \
+19 Sep 2025 
+
 
 ## Fine-tuning Methods
 


### PR DESCRIPTION

Hey, thanks for keeping this list up to date, it's a great reference. I'd like to add our EMNLP 2025 (Main) paper PersonaEvolve to the LLM Optimization section. It's an LLM-as-optimizer that iteratively refines agent personas (their prompts) to minimize behavioral distribution divergence, so it sits naturally alongside OPRO, EvoPrompt, and APE. https://arxiv.org/abs/2509.16457

---
Implicit Behavioral Alignment of Language Agents in High-Stakes Crowd Simulations (EMNLP 2025 Main)
arXiv: https://arxiv.org/abs/2509.16457
PDF: https://arxiv.org/pdf/2509.16457